### PR TITLE
[AI-5] Allow background delivery via expo

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -21,13 +21,13 @@
                  ascending:(BOOL)asc
                      limit:(NSUInteger)lim
                 completion:(void (^)(NSArray *, NSError *))completion {
-    
+
     NSSortDescriptor *timeSortDescriptor = [[NSSortDescriptor alloc] initWithKey:HKSampleSortIdentifierEndDate
                                                                        ascending:asc];
-    
+
     // declare the block
     void (^handlerBlock)(HKSampleQuery *query, NSArray *results, NSError *error);
-    
+
     // create and assign the block
     handlerBlock = ^(HKSampleQuery *query, NSArray *results, NSError *error) {
         if (!results) {
@@ -36,10 +36,10 @@
             }
             return;
         }
-        
+
         if (completion) {
             NSMutableArray *data = [NSMutableArray arrayWithCapacity:1];
-            
+
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
                 if (type == [HKObjectType workoutType]) {
                     for (HKWorkout *sample in results) {
@@ -52,18 +52,18 @@
                 } else {
                     NSLog(@"RNHealth: Must be workout type ");
                 }
-                
+
                 completion(data, error);
             });
         }
     };
-    
+
     HKSampleQuery *query = [[HKSampleQuery alloc] initWithSampleType:type
                                                            predicate:predicate
                                                                limit:lim
                                                      sortDescriptors:@[timeSortDescriptor]
                                                       resultsHandler:handlerBlock];
-    
+
     [self.healthStore executeQuery:query];
 }
 
@@ -72,34 +72,34 @@
                    anchor:(HKQueryAnchor *)anchor
                     limit:(NSUInteger)lim
                completion:(void (^)(NSDictionary *, NSError *))completion {
-    
+
     // declare the block
     void (^handlerBlock)(HKAnchoredObjectQuery *query, NSArray<__kindof HKSample *> *sampleObjects, NSArray<HKDeletedObject *> *deletedObjects, HKQueryAnchor *newAnchor, NSError *error);
-    
+
     // create and assign the block
     handlerBlock = ^(HKAnchoredObjectQuery *query, NSArray<__kindof HKSample *> *sampleObjects, NSArray<HKDeletedObject *> *deletedObjects, HKQueryAnchor *newAnchor, NSError *error) {
-        
+
         if (!sampleObjects || sampleObjects == nil || [sampleObjects count] == 0) {
             if (completion) {
                 completion(nil, error);
             }
             return;
         }
-        
+
         if (completion) {
-            
+
             //init store for locations
             NSMutableArray *locations = [NSMutableArray arrayWithCapacity:1];
-            
+
             //only one route should return in the samples
             for(HKWorkoutRoute*routeSample in sampleObjects){
-                
+
             //create and assign the block to fetch locations
             void(^locationsHandlerBlock)(HKWorkoutRouteQuery* query, NSArray<CLLocation*>* routeData, BOOL done, NSError* error);
-            
+
             locationsHandlerBlock = ^(HKWorkoutRouteQuery* query, NSArray<CLLocation*>* routeData, BOOL done, NSError* error)
             {
-                
+
                 if(!routeData){
                     //no data associated with route
                     if(done){
@@ -108,7 +108,7 @@
                     }
                     return;
                 }
-                
+
                 //process each batch and store
                 for (CLLocation *sample in routeData) {
                     @try {
@@ -116,7 +116,7 @@
                         double lng = sample.coordinate.longitude;
                         double alt = sample.altitude;
                         NSString*timestamp = [RCTAppleHealthKit buildISO8601StringFromDate:sample.timestamp];
-                        
+
                         NSDictionary *elem = @{
                             @"latitude" :@(lat),
                             @"longitude": @(lng),
@@ -125,20 +125,20 @@
                             @"speed": @(sample.speed),
                             @"speedAccuracy": @(sample.speedAccuracy)
                         };
-                        
+
                         [locations addObject:elem];
                     } @catch (NSException *exception) {
                         NSLog(@"RNHealth: An error occured while trying to add route sample from: %@ ", [[[routeSample sourceRevision] source] bundleIdentifier]);
                     }
                 }
-                
+
                 if(done) {
                     //all batches successfully completed
                     NSData *anchorData = [NSKeyedArchiver archivedDataWithRootObject:newAnchor];
                     NSString *anchorString = [anchorData base64EncodedStringWithOptions:0];
                     NSString *start = [RCTAppleHealthKit buildISO8601StringFromDate:routeSample.startDate];
                     NSString *end = [RCTAppleHealthKit buildISO8601StringFromDate:routeSample.endDate];
-                    
+
                     NSString* device = @"";
                     if (@available(iOS 11.0, *)) {
                         device = [[routeSample sourceRevision] productType];
@@ -148,10 +148,10 @@
                             device = @"iPhone";
                         }
                     }
-                    
-                    
+
+
                     NSObject*metaData = [routeSample metadata] ? [routeSample metadata] : @{};
-                    
+
                     NSDictionary *routeElem = @{
                         @"id" : [[routeSample UUID] UUIDString],
                         @"sourceId": [[[routeSample sourceRevision] source] bundleIdentifier],
@@ -162,32 +162,32 @@
                         @"end":end,
                         @"locations": locations
                     };
-                    
-                    
+
+
                     completion(@{
                             @"anchor": anchorString,
                             @"data": routeElem,
                         }, error);
                 }
-            
+
             };
-                
+
                 HKWorkoutRouteQuery* routeQuery = [[HKWorkoutRouteQuery alloc] initWithRoute:routeSample
                                                                                  dataHandler:locationsHandlerBlock];
                 [self.healthStore executeQuery:routeQuery];
-            
+
             }
-            
+
         }
     };
-    
+
     HKAnchoredObjectQuery *query = [[HKAnchoredObjectQuery alloc] initWithType:type
                                                                      predicate:predicate
                                                                         anchor:anchor
                                                                          limit:HKObjectQueryNoLimit
                                                                 resultsHandler:handlerBlock
     ];
-    
+
     [self.healthStore executeQuery:query];
 }
 
@@ -393,6 +393,7 @@
 
                             NSDictionary *elem = @{
                                                    valueType : @(value),
+                                                   @"id" : [[sample UUID] UUIDString],
                                                    @"tracked" : @(isTracked),
                                                    @"sourceName" : [[[sample sourceRevision] source] name],
                                                    @"sourceId" : [[[sample sourceRevision] source] bundleIdentifier],

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
@@ -18,11 +18,11 @@ NSString * const kMetadataKey = @"metadata";
 + (NSArray *)formatWorkoutEvents:(NSArray *)workoutEvents
 {
     NSMutableArray *formattedWorkEvents = [[NSMutableArray alloc] init];
-    
+
     for (id workoutEvent in workoutEvents) {
         NSNumber *eventType = [workoutEvent valueForKey:@"type"];
         NSString *eventDescription = @"";
-        
+
         switch([eventType intValue]) {
             case (int)HKWorkoutEventTypePause:
                 eventDescription = @"pause";
@@ -50,8 +50,8 @@ NSString * const kMetadataKey = @"metadata";
             default:
                 eventDescription = @"";
         }
-        
-        
+
+
         NSObject *formattedEvent = @{
             @"eventTypeInt":eventType,
             @"eventType": eventDescription,
@@ -60,7 +60,7 @@ NSString * const kMetadataKey = @"metadata";
         };
         [formattedWorkEvents addObject: formattedEvent];
     }
-    
+
     return formattedWorkEvents;
 }
 
@@ -90,7 +90,7 @@ NSString * const kMetadataKey = @"metadata";
     } @catch (NSException *exception) {
         NSLog(@"RNHealth: An error occured while trying parse ISO8601 string from date");
         return nil;
-    }   
+    }
 }
 
 
@@ -224,6 +224,8 @@ NSString * const kMetadataKey = @"metadata";
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierStepCount];
     } else if ([type isEqual:@"Workout"]) {
         return [HKObjectType workoutType];
+    }  else if ([type isEqual:@"SleepAnalysis"]) {
+        return [HKObjectType categoryTypeForIdentifier:HKCategoryTypeIdentifierSleepAnalysis];
     }
 
     return [HKObjectType workoutType];
@@ -247,13 +249,13 @@ NSString * const kMetadataKey = @"metadata";
             return [HKObjectType clinicalTypeForIdentifier:HKClinicalTypeIdentifierVitalSignRecord];
         }
     }
-    
+
     if (@available(iOS 14.0, *)) {
          if ([type isEqual:@"CoverageRecord"]){
              return [HKObjectType clinicalTypeForIdentifier:HKClinicalTypeIdentifierCoverageRecord];
          }
     }
-    
+
     return nil;
 }
 

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,13 +1,54 @@
-const { withEntitlementsPlist, withInfoPlist } = require('@expo/config-plugins')
+const { withAppDelegate, withEntitlementsPlist, withInfoPlist } = require('@expo/config-plugins')
+const {
+  mergeContents
+} = require('@expo/config-plugins/build/utils/generateCode')
+
+const RN_HEALTH_IMPORT = '#import "RCTAppleHealthKit.h"'
+const RN_HEALTH_BRIDGE = '  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];'
+const RN_HEALTH_INITIALIZE = '  [[RCTAppleHealthKit new] initializeBackgroundObservers:bridge];'
 
 const HEALTH_SHARE = 'Allow $(PRODUCT_NAME) to check health info'
 const HEALTH_UPDATE = 'Allow $(PRODUCT_NAME) to update health info'
 const HEALTH_CLINIC_SHARE = 'Allow $(PRODUCT_NAME) to check health clinical info'
 
+function addImport(src) {
+  const newSrc = [RN_HEALTH_IMPORT]
+  return mergeContents({
+    tag: 'healthkit-import',
+    src,
+    newSrc: newSrc.join('\n'),
+    anchor: /#import "AppDelegate\.h"/,
+    offset: 1,
+    comment: '//'
+  })
+}
+
+function addInit(src) {
+  const newSrc = [RN_HEALTH_BRIDGE, RN_HEALTH_INITIALIZE]
+  return mergeContents({
+    tag: 'healthkit-init',
+    src,
+    newSrc: newSrc.join('\n'),
+    anchor: /self.initialProps = @{};/,
+    offset: 1,
+    comment: '  //'
+  })
+}
+
+
 const withHealthKit = (
   config,
-  { healthSharePermission, healthUpdatePermission, isClinicalDataEnabled, healthClinicalDescription } = {},
+  { healthSharePermission, healthUpdatePermission, isClinicalDataEnabled, healthClinicalDescription, isBackgroundDeliveryEnabled } = {},
 ) => {
+  // Add import
+  config = withAppDelegate(config, (config) => {
+    if (config.modResults.language === 'objcpp') {
+      config.modResults.contents = addImport(config.modResults.contents).contents
+      config.modResults.contents = addInit(config.modResults.contents).contents
+    }
+    return config
+  })
+
   // Add permissions
   config = withInfoPlist(config, (config) => {
     config.modResults.NSHealthShareUsageDescription =
@@ -31,6 +72,9 @@ const withHealthKit = (
   // Add entitlements. These are automatically synced when using EAS build for production apps.
   config = withEntitlementsPlist(config, (config) => {
     config.modResults['com.apple.developer.healthkit'] = true
+    if (isBackgroundDeliveryEnabled) {
+      config.modResults['com.apple.developer.healthkit.background-delivery'] = true
+    }
     if (
       !Array.isArray(config.modResults['com.apple.developer.healthkit.access'])
     ) {


### PR DESCRIPTION
## Description

- Allow background data delivery configuration via expo
- Add sleep analysis support for background delivery
- Add id to `getSamples`

https://linear.app/brightside-healthcare/issue/AI-5/integrate-healthkit-into-stringer

Stringer changes: https://github.com/brightsidehealth/stringer/pull/961
